### PR TITLE
Add app name

### DIFF
--- a/setty/context_processors.py
+++ b/setty/context_processors.py
@@ -1,4 +1,6 @@
 import setty
+from django.conf import settings
+from django.urls import resolve
 
 
 def setty_settings(request):
@@ -8,7 +10,8 @@ def setty_settings(request):
     Add 'setty.context_processors.setty_settings' to the
     TEMPLATE_CONTEXT_PROCESSORS setting to ensure this can be used.
     """
-    tags = {f'setty_{app}': setty.config.get_for_app(app) for app in settings.INSTALLED_APPS}
-    tags['setty'] = setty.config
+
+    app_name = resolve(request.path).app_name
+    tags = {'setty_current_app': setty.config.get_for_app(app_name), 'setty': setty.config}
 
     return tags

--- a/setty/context_processors.py
+++ b/setty/context_processors.py
@@ -11,7 +11,9 @@ def setty_settings(request):
     TEMPLATE_CONTEXT_PROCESSORS setting to ensure this can be used.
     """
 
+    tags = {'setty': setty.config}
     app_name = resolve(request.path).app_name
-    tags = {'setty_current_app': setty.config.get_for_app(app_name), 'setty': setty.config}
+    if app_name:
+        tags['setty_current_app'] = setty.config.get_for_app(app_name)
 
     return tags

--- a/setty/exceptions.py
+++ b/setty/exceptions.py
@@ -4,3 +4,7 @@ class InvalidConfigurationError(Exception):
 
 class SettingDoesNotExistError(Exception):
     pass
+
+
+class NotAppNameProvide(Exception):
+    pass

--- a/setty/exceptions.py
+++ b/setty/exceptions.py
@@ -4,7 +4,3 @@ class InvalidConfigurationError(Exception):
 
 class SettingDoesNotExistError(Exception):
     pass
-
-
-class NotAppNameProvide(Exception):
-    pass

--- a/setty/wrapper.py
+++ b/setty/wrapper.py
@@ -29,4 +29,4 @@ class Settings:
         return [setting.name for setting in self._backend.get_all()]
 
     def get_for_app(self, app_name):
-        return {setting.name: setting.value for setting in self._backend.get_all(app_name)}
+        return [setting for setting in self._backend.get_all(app_name)]


### PR DESCRIPTION
to correct mapping settings to JS, need variable type. 

To work, you must specify app_name in urls.py or namespaces in include. [docs](https://docs.djangoproject.com/en/3.0/topics/http/urls/#introduction)

my use case:

```
<!-- Load settings -->
<script>
    {% for s in setty_current_app %}
        {% if s.type == 'string' %}
            var {{ s.name }} = '{{ s.value }}';
        {% else %}
            var {{ s.name }} = {{ s.value }};
        {% endif %}
    {% endfor %}
</script>
```